### PR TITLE
Add .NET runtime guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # WSAppBak
  APPX Backupper and Repacker
  
- Info:
- 
- This was not made by me, i found it somewhere, and decompiled it.
+Info:
+
+This was not made by me, i found it somewhere, and decompiled it.
+
+## Requirements
+
+The tool requires the **.NET 8 Windows Desktop runtime** to run. You can install
+it from <https://dotnet.microsoft.com/download/dotnet/8.0>.

--- a/WSAppBak.cs
+++ b/WSAppBak.cs
@@ -27,14 +27,47 @@ namespace WSAppBak
 
 		private string WSAppOutputPath;
 
-		private string WSAppProcessorArchitecture;
+private string WSAppProcessorArchitecture;
 
-		private string WSAppPublisher;
+private string WSAppPublisher;
 
-		public void Run()
-		{
-			ReadArg();
-		}
+// Returns true if .NET 8 Windows Desktop runtime is installed.
+private bool CheckDotnetRuntime()
+{
+try
+{
+Process proc = new Process
+{
+StartInfo = new ProcessStartInfo
+{
+FileName = "dotnet",
+Arguments = "--list-runtimes",
+UseShellExecute = false,
+RedirectStandardOutput = true,
+CreateNoWindow = true
+}
+};
+proc.Start();
+string list = proc.StandardOutput.ReadToEnd();
+proc.WaitForExit();
+return list.Contains("Microsoft.WindowsDesktop.App 8.");
+}
+catch (Exception ex)
+{
+Console.WriteLine($"Failed to verify .NET runtime: {ex.Message}");
+return false;
+}
+}
+
+public void Run()
+{
+if (!CheckDotnetRuntime())
+{
+Console.WriteLine("Required .NET 8 runtime not found. Please install it from https://dotnet.microsoft.com/download/dotnet/8.0 and try again.");
+return;
+}
+ReadArg();
+}
 
 		private string RunProcess(string fileName, string args)
 		{


### PR DESCRIPTION
## Summary
- clarify that .NET 8 runtime is required
- link to download site when runtime is missing

## Testing
- `dotnet publish -r win-x64 -c Release --no-self-contained` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6861cf86ddd0833191edf0397c4e6773