### PR TITLE
Allow CLI arguments for paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,17 @@ it from <https://dotnet.microsoft.com/download/dotnet/8.0>.
 It also depends on the **Windows SDK tools** (`MakeAppx.exe`, `MakeCert.exe`,
 `Pvk2Pfx.exe`, `SignTool.exe`). If they are missing on your machine, install the
 Windows SDK from <https://developer.microsoft.com/windows/downloads/windows-10-sdk/>.
+
+## Usage
+
+Run without arguments for interactive mode:
+
+```bash
+WSAppBak.exe
+```
+
+Specify input and output folders to run non-interactively:
+
+```bash
+WSAppBak.exe <appPath> <outputPath>
+```

--- a/WSAppBak.cs
+++ b/WSAppBak.cs
@@ -19,9 +19,33 @@ namespace WSAppBak
         private string WSAppFileName;
         private string WSAppPublisher;
 
-        public void Run()
+        public void Run(string[] args)
         {
-            ReadArg();
+            if (args.Length == 2)
+            {
+                WSAppPath       = args[0].Trim('"');
+                WSAppOutputPath = args[1].Trim('"');
+
+                if (!File.Exists(Path.Combine(WSAppPath, WSAppXmlFile)))
+                {
+                    Console.WriteLine($"Invalid App Path; '{WSAppXmlFile}' not found!");
+                    return;
+                }
+
+                if (!Directory.Exists(WSAppOutputPath))
+                {
+                    Console.WriteLine("Invalid Output Path; directory not found!");
+                    return;
+                }
+
+                WSAppFileName = Path.GetFileName(WSAppPath);
+                ExtractPublisherFromManifest();
+                MakeAppx();
+            }
+            else
+            {
+                ReadArg();
+            }
         }
 
         private void ReadArg()

--- a/WSAppBakExecute.cs
+++ b/WSAppBakExecute.cs
@@ -3,10 +3,10 @@ using WSAppBak;
 
 internal class WSAppBakExecute
 {
-	private static void Main(string[] args)
-	{
-		Console.Title = "WSAppBak";
-		WSAppBak.WSAppBak wSAppBak = new WSAppBak.WSAppBak();
-		wSAppBak.Run();
-	}
+        private static void Main(string[] args)
+        {
+                Console.Title = "WSAppBak";
+                WSAppBak.WSAppBak wSAppBak = new WSAppBak.WSAppBak();
+                wSAppBak.Run(args);
+        }
 }


### PR DESCRIPTION
## Summary
- add CLI support for input and output folders
- document new command line usage

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864353fd4008331866fa0ba43236c95