### PR TITLE
Remove explicit assembly versions

### DIFF
--- a/WSAppBak.sln
+++ b/WSAppBak.sln
@@ -1,7 +1,7 @@
 
 Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual Studio 2010
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WSAppBak", "WSAppBak.csproj", "{FC7B1B80-85F4-4053-A060-D2B8288CA19B}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WSAppBak", "src\WSAppBak.csproj", "{FC7B1B80-85F4-4053-A060-D2B8288CA19B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/AssemblyInfo.cs
+++ b/src/AssemblyInfo.cs
@@ -10,5 +10,3 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("f98280ba-6013-4592-8949-dc2ac99d60f3")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyVersion("1.0.0.0")]


### PR DESCRIPTION
## Summary
- remove assembly version attributes from `AssemblyInfo.cs`

## Testing
- `git status --short`
- `dotnet build src/WSAppBak.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864969ae6fc8331b063a01a5b8c8103