### PR TITLE
Remove BOM from AssemblyInfo

### DIFF
--- a/src/AssemblyInfo.cs
+++ b/src/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("WSAppBak")]


### PR DESCRIPTION
## Summary
- strip UTF-8 BOM from `src/AssemblyInfo.cs`

## Testing
- `dotnet build WSAppBak.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6864a46851b88331965bf4179453b37a